### PR TITLE
enumerate SRIOV caps for all the ports

### DIFF
--- a/src/vfd/sriov.c
+++ b/src/vfd/sriov.c
@@ -813,7 +813,7 @@ vf_stats_display(uint8_t port_id, uint32_t pf_ari, int ivf, char * buff, int bsi
 	struct rte_pci_addr vf_pci_addr;
 
 
-	new_ari = pf_ari + vf_offfset + (vf * vf_stride);
+	new_ari = pf_ari + vf_offfset[port_id] + (vf * vf_stride[port_id]);
 
 	vf_pci_addr.domain = 0;
 	vf_pci_addr.bus = (new_ari >> 8) & 0xff;

--- a/src/vfd/sriov.h
+++ b/src/vfd/sriov.h
@@ -351,8 +351,8 @@ struct timeval startTime;
 struct timeval endTime;
 
 // will keep PCI First VF offset and Stride here
-uint16_t vf_offfset;
-uint16_t vf_stride;
+uint16_t vf_offfset[MAX_PORTS];
+uint16_t vf_stride[MAX_PORTS];
 
 uint32_t spoffed[MAX_PORTS]; 		// # of spoffed packets per PF
 


### PR DESCRIPTION
Currently we seem to be reading SRIOV capabilities including
VF stride and VF offset only for port 0.
Which seem to enumerate VFs for non-zero ports wrongly.
Read the capabilities for all the ports and save the VF_offfset/stride
appropriately.

Signed-off-by: Ajit Khaparde <ajit.khaparde@broadcom.com>