### PR TITLE
expand spoffed to 64-bits

### DIFF
--- a/src/vfd/main.c
+++ b/src/vfd/main.c
@@ -250,7 +250,7 @@ static struct sriov_port_s *suss_port( int portid ) {
 /*
 	Given a port and vfid, find the vf block and return a pointer to it.
 */
-static struct vf_s *suss_vf( int port, int vfid ) {
+struct vf_s *suss_vf( int port, int vfid ) {
 	struct sriov_port_s *p;
 	int		i;
 

--- a/src/vfd/sriov.c
+++ b/src/vfd/sriov.c
@@ -883,9 +883,9 @@ vf_stats_display(uint8_t port_id, uint32_t pf_ari, int ivf, char * buff, int bsi
 #ifdef BNXT_SUPPORT
 	if (is_bnxt) {
 		if (rte_pmd_bnxt_get_vf_rx_status(port_id, vf) <= 0)
-	    		stpcpy(status, "UP  ");
-		else
 			stpcpy(status, "DOWN");
+		else
+	    		stpcpy(status, "UP  ");
 	}
 	else
 #endif

--- a/src/vfd/sriov.h
+++ b/src/vfd/sriov.h
@@ -354,7 +354,7 @@ struct timeval endTime;
 uint16_t vf_offfset[MAX_PORTS];
 uint16_t vf_stride[MAX_PORTS];
 
-uint32_t spoffed[MAX_PORTS]; 		// # of spoffed packets per PF
+uint64_t spoffed[MAX_PORTS]; 		// # of spoffed packets per PF
 
 struct rq_entry *rq_list;			// reset queue list of VMs we are waiting on queue ready bits for
 
@@ -419,6 +419,7 @@ void restore_vf_setings(uint8_t port_id, int vf);
 int valid_mtu( int port, int mtu );
 int valid_vlan( int port, int vfid, int vlan );
 int get_vf_setting( int portid, int vf, int what );
+struct vf_s *suss_vf( int port, int vfid );
 
 void add_refresh_queue(u_int8_t port_id, uint16_t vf_id);
 void process_refresh_queue(void);


### PR DESCRIPTION
clean up multi-nic support so same binary can suport BNXT and Intel
include TX errors and drops in VF output with bnxt
enforce MAC addresses listed in config file
- If there's no MACs listed, the MAC anti-spoof is somewhat disabled
- This is done using the callback and denying HWRM calls that change
  or add MAC addresses