### PR TITLE
build vfd against 17.11 DPDK

### DIFF
--- a/src/vfd/main.c
+++ b/src/vfd/main.c
@@ -1211,7 +1211,7 @@ timeDelta(struct timeval * now, struct timeval * before)
 	we are currently managing.
 */
 void
-restore_vf_setings(uint8_t port_id, int vf_id) {
+restore_vf_setings(uint16_t port_id, int vf_id) {
 	int i;
 	int matched = 0;		// number matched for log
 

--- a/src/vfd/sriov.c
+++ b/src/vfd/sriov.c
@@ -1159,7 +1159,7 @@ nic_stats_clear(portid_t port_id)
 
 
 int
-nic_stats_display(uint8_t port_id, char * buff, int bsize)
+nic_stats_display(uint16_t port_id, char * buff, int bsize)
 {
 	struct rte_eth_stats stats;
 	struct rte_eth_link link;
@@ -1219,7 +1219,7 @@ nic_stats_display(uint8_t port_id, char * buff, int bsize)
 	It is converted to uint32 for calculations here.
 */
 int
-vf_stats_display(uint8_t port_id, uint32_t pf_ari, int ivf, char * buff, int bsize)
+vf_stats_display(uint16_t port_id, uint32_t pf_ari, int ivf, char * buff, int bsize)
 {
 	uint32_t vf;
 	int result = 0;
@@ -1314,7 +1314,7 @@ vf_stats_display(uint8_t port_id, uint32_t pf_ari, int ivf, char * buff, int bsi
 	eturns number of characters placed into buff.
 */
 int
-port_xstats_display(uint8_t port_id, char * buff, int bsize)
+port_xstats_display(uint16_t port_id, char * buff, int bsize)
 {
 	struct rte_eth_xstat *xstats;
 	int cnt_xstats, idx_xstat;
@@ -1399,6 +1399,35 @@ dump_all_vlans(portid_t port_id)
 }
 
 
+//int lsi_event_callback(uint16_t port_id, enum rte_eth_event_type type, void *param, void *ret_param)
+int lsi_event_callback(uint16_t port_id, enum rte_eth_event_type type, void *param, void* data )
+{
+	struct rte_eth_link link;
+
+	RTE_SET_USED(param);
+	RTE_SET_USED(data);
+
+	bleat_printf( 3, "Event type: %s", type == RTE_ETH_EVENT_INTR_LSC ? "LSC interrupt" : "unknown event");
+	rte_eth_link_get_nowait(port_id, &link);
+	if (link.link_status) {
+		bleat_printf( 3, "Port %d Link Up - speed %u Mbps - %s",
+				port_id, (unsigned)link.link_speed,
+			(link.link_duplex == ETH_LINK_FULL_DUPLEX) ?
+				("full-duplex") : ("half-duplex"));
+
+		if( type == RTE_ETH_EVENT_INTR_LSC ) {
+			restore_vf_setings( port_id, -1 );				// reset _all_ VFs on the port
+		}
+	} else
+		bleat_printf( 3, "Port %d Link Down", port_id);
+
+	// notify every VF about link status change
+	ping_vfs(port_id, -1);
+
+	return 0;   // CAUTION:  as of 2017/07/05 it seems this value is ignored by dpdk, but it might not alwyas be
+}
+
+
 /*
 	Initialise a device (port).
 	Return 0 if there were no errors, 1 otherwise.  The calling programme should
@@ -1409,7 +1438,7 @@ dump_all_vlans(portid_t port_id)
 	If hw_strip_crc is false, the default will be overridden.
 */
 int
-port_init(uint8_t port, __attribute__((__unused__)) struct rte_mempool *mbuf_pool, int hw_strip_crc, __attribute__((__unused__)) sriov_port_t *pf )
+port_init(uint16_t port, __attribute__((__unused__)) struct rte_mempool *mbuf_pool, int hw_strip_crc, __attribute__((__unused__)) sriov_port_t *pf )
 {
 	struct rte_eth_conf port_conf = port_conf_default;
 	const uint16_t rx_rings = 1;
@@ -1440,7 +1469,9 @@ port_init(uint8_t port, __attribute__((__unused__)) struct rte_mempool *mbuf_poo
 		return 1;
 	}
 
-	rte_eth_dev_callback_register(port, RTE_ETH_EVENT_INTR_LSC, lsi_event_callback, NULL);
+	rte_eth_dev_callback_register(port,
+				RTE_ETH_EVENT_INTR_LSC,
+				lsi_event_callback, NULL);
 	
 	
 	uint dev_type = get_nic_type(port);
@@ -1565,36 +1596,6 @@ extern void set_fc_on( portid_t pf, int force ) {
 	rte_eth_dev_flow_ctrl_set( pf, &fcstate );
 }
 
-
-
-//lsi_event_callback(uint8_t port_id, enum rte_eth_event_type type, void *param, __attribute__((__unused__)) void *data)
-int 
-lsi_event_callback(uint8_t port_id, enum rte_eth_event_type type, void *param, void *data)
-{
-	struct rte_eth_link link;
-
-	RTE_SET_USED(param);
-	RTE_SET_USED(data);
-
-	bleat_printf( 3, "Event type: %s", type == RTE_ETH_EVENT_INTR_LSC ? "LSC interrupt" : "unknown event");
-	rte_eth_link_get_nowait(port_id, &link);
-	if (link.link_status) {
-		bleat_printf( 3, "Port %d Link Up - speed %u Mbps - %s",
-				port_id, (unsigned)link.link_speed,
-			(link.link_duplex == ETH_LINK_FULL_DUPLEX) ?
-				("full-duplex") : ("half-duplex"));
-
-		if( type == RTE_ETH_EVENT_INTR_LSC ) {
-			restore_vf_setings( port_id, -1 );				// reset _all_ VFs on the port
-		}
-	} else
-		bleat_printf( 3, "Port %d Link Down", port_id);
-
-	// notify every VF about link status change
-	ping_vfs(port_id, -1);
-
-	return 0;   // CAUTION:  as of 2017/07/05 it seems this value is ignored by dpdk, but it might not alwyas be
-}
 
 
 void

--- a/src/vfd/sriov.h
+++ b/src/vfd/sriov.h
@@ -65,6 +65,7 @@
 #include <rte_mbuf.h>
 #include <rte_interrupts.h>
 #include <rte_pci.h>
+#include <rte_bus_pci.h>
 #include <rte_ether.h>
 #include <rte_ethdev.h>
 #include <rte_string_fns.h>
@@ -142,7 +143,7 @@ typedef unsigned int uint128_t __attribute__((mode(TI)));
 #define MAX_PF_MACS  128	// mac count across all PFs cannot exceed
 
 typedef uint8_t  lcoreid_t;
-typedef uint8_t  portid_t;
+typedef uint16_t  portid_t;
 typedef uint16_t queueid_t;
 typedef uint16_t streamid_t;
 
@@ -411,13 +412,13 @@ int set_vf_rate_limit(portid_t port_id, uint16_t vf, uint16_t rate, uint64_t q_m
 int set_vf_link_status(portid_t port_id, uint16_t vf, int status);
 
 void nic_stats_clear(portid_t port_id);
-int nic_stats_display(uint8_t port_id, char * buff, int blen);
-int vf_stats_display(uint8_t port_id, uint32_t pf_ari, int vf, char * buff, int bsize);
-int port_xstats_display(uint8_t port_id, char * buff, int bsize);
+int nic_stats_display(uint16_t port_id, char * buff, int blen);
+int vf_stats_display(uint16_t port_id, uint32_t pf_ari, int vf, char * buff, int bsize);
+int port_xstats_display(uint16_t port_id, char * buff, int bsize);
 int dump_all_vlans(portid_t port_id);
 void ping_vfs(portid_t port_id, int vf);
 
-int port_init(uint8_t port, struct rte_mempool *mbuf_pool, int hw_strip_crc, sriov_port_t *pf );
+int port_init(uint16_t port, struct rte_mempool *mbuf_pool, int hw_strip_crc, sriov_port_t *pf );
 void tx_set_loopback(portid_t port_id, u_int8_t on);
 
 void ether_aton_r(const char *asc, struct ether_addr * addr);
@@ -438,10 +439,9 @@ int update_ports_config(void);
 int cmp_vfs (const void * a, const void * b);
 void disable_default_pool(portid_t port_id);
 
-int lsi_event_callback(uint8_t port_id, enum rte_eth_event_type type, void *param, void* data );
-void ixgbe_vf_msb_event_callback(uint8_t port_id, enum rte_eth_event_type type, void *param);
-void bnxt_vf_msb_event_callback(uint8_t port_id, enum rte_eth_event_type type, void *param);
-void restore_vf_setings(uint8_t port_id, int vf);
+int lsi_event_callback(uint16_t port_id, enum rte_eth_event_type type, void *param, void* data );
+//int lsi_event_callback(uint16_t port_id, enum rte_eth_event_type type, void *param, void *ret_param);
+void restore_vf_setings(uint16_t port_id, int vf);
 
 // callback validation support
 int valid_mtu( int port, int mtu );

--- a/src/vfd/vfd_bnxt.c
+++ b/src/vfd/vfd_bnxt.c
@@ -4,7 +4,7 @@
 
 
 int  
-vfd_bnxt_ping_vfs(uint8_t port_id, int16_t vf_id)
+vfd_bnxt_ping_vfs(uint16_t port_id, int16_t vf_id)
 {
 		/* TODO */
 	bleat_printf( 0, "vfd_bnxt_ping_vfs(): not implemented for port=%d, vf=%d, qstart=%d ", port_id, vf_id );
@@ -13,7 +13,7 @@ vfd_bnxt_ping_vfs(uint8_t port_id, int16_t vf_id)
 
 
 int 
-vfd_bnxt_set_vf_mac_anti_spoof(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_bnxt_set_vf_mac_anti_spoof(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 	int diag = rte_pmd_bnxt_set_vf_mac_anti_spoof(port_id, vf_id, on);
 	if (diag < 0) {
@@ -27,7 +27,7 @@ vfd_bnxt_set_vf_mac_anti_spoof(uint8_t port_id, uint16_t vf_id, uint8_t on)
 
 
 int 
-vfd_bnxt_set_vf_vlan_anti_spoof(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_bnxt_set_vf_vlan_anti_spoof(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 
 
@@ -43,7 +43,7 @@ vfd_bnxt_set_vf_vlan_anti_spoof(uint8_t port_id, uint16_t vf_id, uint8_t on)
 
 
 int 
-vfd_bnxt_set_tx_loopback(uint8_t port_id, uint8_t on)
+vfd_bnxt_set_tx_loopback(uint16_t port_id, uint8_t on)
 {
 	int diag = rte_pmd_bnxt_set_tx_loopback(port_id, on);
 	if (diag < 0) {
@@ -57,7 +57,7 @@ vfd_bnxt_set_tx_loopback(uint8_t port_id, uint8_t on)
 
 
 int 
-vfd_bnxt_set_vf_unicast_promisc(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_bnxt_set_vf_unicast_promisc(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 	int diag = rte_pmd_bnxt_set_vf_rxmode(port_id, vf_id, ETH_VMDQ_ACCEPT_HASH_UC,(uint8_t) on);
 	if (diag < 0) {
@@ -71,7 +71,7 @@ vfd_bnxt_set_vf_unicast_promisc(uint8_t port_id, uint16_t vf_id, uint8_t on)
 
 
 int 
-vfd_bnxt_set_vf_multicast_promisc(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_bnxt_set_vf_multicast_promisc(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 	int diag = rte_pmd_bnxt_set_vf_rxmode(port_id, vf_id, ETH_VMDQ_ACCEPT_MULTICAST,(uint8_t) on);
 	if (diag < 0) {
@@ -89,7 +89,7 @@ vfd_bnxt_set_vf_multicast_promisc(uint8_t port_id, uint16_t vf_id, uint8_t on)
 	for adding a MAC as the default (guest visible) MAC address.
 */
 int 
-vfd_bnxt_set_vf_mac_addr(uint8_t port_id, uint16_t vf_id, struct ether_addr *mac_addr)
+vfd_bnxt_set_vf_mac_addr(uint16_t port_id, uint16_t vf_id, struct ether_addr *mac_addr)
 {
 	int diag = rte_pmd_bnxt_mac_addr_add(port_id, mac_addr, vf_id );
 	if (diag < 0) {
@@ -104,7 +104,7 @@ vfd_bnxt_set_vf_mac_addr(uint8_t port_id, uint16_t vf_id, struct ether_addr *mac
 /*
 	Set the default rx MAC address for the pf/vf. This is the address that will be visible into the guest.
 */
-int vfd_bnxt_set_vf_default_mac_addr( uint8_t port_id, uint16_t vf_id, struct ether_addr *mac_addr ) {
+int vfd_bnxt_set_vf_default_mac_addr( uint16_t port_id, uint16_t vf_id, struct ether_addr *mac_addr ) {
 	int diag;
 
 	diag  = rte_pmd_bnxt_set_vf_mac_addr(port_id, vf_id, mac_addr);
@@ -122,7 +122,7 @@ int vfd_bnxt_set_vf_default_mac_addr( uint8_t port_id, uint16_t vf_id, struct et
 
 
 int 
-vfd_bnxt_set_vf_vlan_stripq(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_bnxt_set_vf_vlan_stripq(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 	int diag = rte_pmd_bnxt_set_vf_vlan_stripq(port_id, vf_id, on);
 	if (diag < 0) {
@@ -136,7 +136,7 @@ vfd_bnxt_set_vf_vlan_stripq(uint8_t port_id, uint16_t vf_id, uint8_t on)
 
 
 int 
-vfd_bnxt_set_vf_vlan_insert(uint8_t port_id, uint16_t vf_id, uint16_t vlan_id)
+vfd_bnxt_set_vf_vlan_insert(uint16_t port_id, uint16_t vf_id, uint16_t vlan_id)
 {
 	int diag = rte_pmd_bnxt_set_vf_vlan_insert(port_id, vf_id, vlan_id);
 	if (diag < 0) {
@@ -150,7 +150,7 @@ vfd_bnxt_set_vf_vlan_insert(uint8_t port_id, uint16_t vf_id, uint16_t vlan_id)
 
 
 int 
-vfd_bnxt_set_vf_broadcast(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_bnxt_set_vf_broadcast(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 	int diag = rte_pmd_bnxt_set_vf_rxmode(port_id, vf_id, ETH_VMDQ_ACCEPT_BROADCAST,(uint8_t) on);
 	if (diag < 0) {
@@ -164,7 +164,7 @@ vfd_bnxt_set_vf_broadcast(uint8_t port_id, uint16_t vf_id, uint8_t on)
 
 
 int 
-vfd_bnxt_set_vf_vlan_tag(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_bnxt_set_vf_vlan_tag(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 
 	bleat_printf( 0, "vfd_bnxt_set_vf_vlan_tag(): not implemented for port=%d, vf=%d, on/off=%d", port_id, vf_id, !!on );
@@ -184,7 +184,7 @@ vfd_bnxt_set_vf_vlan_tag(uint8_t port_id, uint16_t vf_id, uint8_t on)
 
 
 int 
-vfd_bnxt_set_vf_vlan_filter(uint8_t port_id, uint16_t vlan_id, __attribute__((__unused__)) uint64_t vf_mask,  __attribute__((__unused__)) uint8_t on)
+vfd_bnxt_set_vf_vlan_filter(uint16_t port_id, uint16_t vlan_id, __attribute__((__unused__)) uint64_t vf_mask,  __attribute__((__unused__)) uint8_t on)
 {
 
 	int diag = rte_pmd_bnxt_set_vf_vlan_filter(port_id, vlan_id, vf_mask, on);
@@ -201,7 +201,7 @@ vfd_bnxt_set_vf_vlan_filter(uint8_t port_id, uint16_t vlan_id, __attribute__((__
 
 
 int 
-vfd_bnxt_get_vf_stats(uint8_t port_id, uint16_t vf_id, struct rte_eth_stats *stats)
+vfd_bnxt_get_vf_stats(uint16_t port_id, uint16_t vf_id, struct rte_eth_stats *stats)
 {
 	int diag = rte_pmd_bnxt_get_vf_stats(port_id, vf_id, stats);
 	if (diag < 0) {
@@ -216,7 +216,7 @@ vfd_bnxt_get_vf_stats(uint8_t port_id, uint16_t vf_id, struct rte_eth_stats *sta
 
 
 int 
-vfd_bnxt_reset_vf_stats(uint8_t port_id, uint16_t vf_id)
+vfd_bnxt_reset_vf_stats(uint16_t port_id, uint16_t vf_id)
 {
 	int diag = rte_pmd_bnxt_reset_vf_stats(port_id, vf_id);
 	if (diag < 0) {
@@ -234,7 +234,7 @@ vfd_bnxt_reset_vf_stats(uint8_t port_id, uint16_t vf_id)
 	Called when a 'mailbox' message is received.  Examine and take action based on
 	the message type.
 */
-static bool verify_mac_address(uint8_t port_id, uint16_t vf, void *mac, void *mask)
+static bool verify_mac_address(uint16_t port_id, uint16_t vf, void *mac, void *mask)
 {
 	struct vf_s *vf_cfg = suss_vf(port_id, vf);
 	struct ether_addr mac_addr;
@@ -267,7 +267,7 @@ static bool verify_mac_address(uint8_t port_id, uint16_t vf, void *mac, void *ma
 	return false;
 }
 
-static void apply_rx_restrictions(uint8_t port_id, uint16_t vf, struct hwrm_cfa_l2_set_rx_mask_input *mi)
+static void apply_rx_restrictions(uint16_t port_id, uint16_t vf, struct hwrm_cfa_l2_set_rx_mask_input *mi)
 {
 	struct vf_s *vf_cfg = suss_vf(port_id, vf);
 
@@ -296,7 +296,7 @@ static void apply_rx_restrictions(uint8_t port_id, uint16_t vf, struct hwrm_cfa_
 
 
 int
-vfd_bnxt_vf_msb_event_callback(uint8_t port_id, enum rte_eth_event_type type, void *data, void *param)
+vfd_bnxt_vf_msb_event_callback(uint16_t port_id, enum rte_eth_event_type type, void *data, void *param)
 {
 	struct rte_pmd_bnxt_mb_event_param *p;
 	struct input *req_base;
@@ -483,7 +483,7 @@ vfd_bnxt_vf_msb_event_callback(uint8_t port_id, enum rte_eth_event_type type, vo
 
 
 int 
-vfd_bnxt_allow_untagged(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_bnxt_allow_untagged(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 	/* not implemented */
 	bleat_printf( 3, "vfd_bnxt_allow_untagged not implemented: port_id=%d, vf_id=%d, on=%d", port_id, vf_id, on);
@@ -492,7 +492,7 @@ vfd_bnxt_allow_untagged(uint8_t port_id, uint16_t vf_id, uint8_t on)
 
 
 int 
-vfd_bnxt_set_all_queues_drop_en(uint8_t port_id, uint8_t on)
+vfd_bnxt_set_all_queues_drop_en(uint16_t port_id, uint8_t on)
 {
 	int diag  = rte_pmd_bnxt_set_all_queues_drop_en( port_id, on );			
 
@@ -506,7 +506,7 @@ vfd_bnxt_set_all_queues_drop_en(uint8_t port_id, uint8_t on)
 
 
 uint32_t
-vfd_bnxt_get_pf_spoof_stats(uint8_t port_id)
+vfd_bnxt_get_pf_spoof_stats(uint16_t port_id)
 {
 	uint64_t spoffed = 0;
 	bleat_printf( 3, "vfd_bnxt_get_pf_spoof_stats: port_id=%d", port_id);
@@ -561,7 +561,7 @@ vfd_bnxt_get_pf_spoof_stats(uint8_t port_id)
 }
 
 uint32_t
-vfd_bnxt_get_vf_spoof_stats(uint8_t port_id, uint16_t vf_id)
+vfd_bnxt_get_vf_spoof_stats(uint16_t port_id, uint16_t vf_id)
 {
 	uint64_t vf_spoffed = 0;
 	bleat_printf( 3, "vfd_bnxt_get_vf_spoof_stats not implemented: port_id=%d, on=%d", port_id, vf_id);
@@ -571,7 +571,7 @@ vfd_bnxt_get_vf_spoof_stats(uint8_t port_id, uint16_t vf_id)
 }
 
 int 
-vfd_bnxt_is_rx_queue_on(uint8_t port_id, uint16_t vf_id, __attribute__((__unused__)) int* mcounter)
+vfd_bnxt_is_rx_queue_on(uint16_t port_id, uint16_t vf_id, __attribute__((__unused__)) int* mcounter)
 {
 	int queues = rte_pmd_bnxt_get_vf_rx_status(port_id, vf_id);
 	
@@ -585,7 +585,7 @@ vfd_bnxt_is_rx_queue_on(uint8_t port_id, uint16_t vf_id, __attribute__((__unused
 
 
 void 
-vfd_bnxt_set_rx_drop(uint8_t port_id, uint16_t vf_id, int state)
+vfd_bnxt_set_rx_drop(uint16_t port_id, uint16_t vf_id, int state)
 {
 	/* TODO */
 	bleat_printf( 0, "vfd_bnxt_set_rx_drop(): not implemented for port=%d, vf=%d, qstart=%d on/off=%d", port_id, vf_id, !!state );
@@ -593,14 +593,14 @@ vfd_bnxt_set_rx_drop(uint8_t port_id, uint16_t vf_id, int state)
 
 
 void 
-vfd_bnxt_set_split_erop(uint8_t port_id, uint16_t vf_id, int state)
+vfd_bnxt_set_split_erop(uint16_t port_id, uint16_t vf_id, int state)
 {
 	/* TODO */
 	bleat_printf( 0, "vfd_bnxt_set_split_erop(): not implemented for port=%d, vf=%d, qstart=%d on/off=%d", port_id, vf_id, !!state );	
 }
 
 int 
-vfd_bnxt_dump_all_vlans(uint8_t port_id)
+vfd_bnxt_dump_all_vlans(uint16_t port_id)
 {
 	/* TODO */
 	bleat_printf( 0, "vfd_bnxt_dump_all_vlans(): not implemented for port=%d", port_id );	

--- a/src/vfd/vfd_bnxt.h
+++ b/src/vfd/vfd_bnxt.h
@@ -11,32 +11,32 @@
 
 // ------------- prototypes ----------------------------------------------
 
-int vfd_bnxt_ping_vfs(uint8_t port, int16_t vf);
-int vfd_bnxt_set_vf_mac_anti_spoof(uint8_t port, uint16_t vf_id, uint8_t on); 
-int vfd_bnxt_set_vf_vlan_anti_spoof(uint8_t port, uint16_t vf_id, uint8_t on);
-int vfd_bnxt_set_tx_loopback(uint8_t port, uint8_t on);
-int vfd_bnxt_set_vf_unicast_promisc(uint8_t port, uint16_t vf_id, uint8_t on);
-int vfd_bnxt_set_vf_multicast_promisc(uint8_t port, uint16_t vf_id, uint8_t on);
-int vfd_bnxt_set_vf_mac_addr(uint8_t port, uint16_t vf_id, struct ether_addr *mac_addr);
-int vfd_bnxt_set_vf_default_mac_addr( uint8_t port_id, uint16_t vf_id, struct ether_addr *mac_addr );
-int vfd_bnxt_set_vf_vlan_stripq(uint8_t port, uint16_t vf, uint8_t on);
-int vfd_bnxt_set_vf_vlan_insert(uint8_t port, uint16_t vf_id, uint16_t vlan_id);
-int vfd_bnxt_set_vf_broadcast(uint8_t port, uint16_t vf_id, uint8_t on);
-int vfd_bnxt_set_vf_vlan_tag(uint8_t port, uint16_t vf_id, uint8_t on);
-int vfd_bnxt_set_vf_vlan_filter(uint8_t port, uint16_t vlan_id, uint64_t vf_mask, uint8_t on);
-int vfd_bnxt_get_vf_stats(uint8_t port, uint16_t vf_id, struct rte_eth_stats *stats);
-int vfd_bnxt_reset_vf_stats(uint8_t port, uint16_t vf_id);
+int vfd_bnxt_ping_vfs(uint16_t port, int16_t vf);
+int vfd_bnxt_set_vf_mac_anti_spoof(uint16_t port, uint16_t vf_id, uint8_t on); 
+int vfd_bnxt_set_vf_vlan_anti_spoof(uint16_t port, uint16_t vf_id, uint8_t on);
+int vfd_bnxt_set_tx_loopback(uint16_t port, uint8_t on);
+int vfd_bnxt_set_vf_unicast_promisc(uint16_t port, uint16_t vf_id, uint8_t on);
+int vfd_bnxt_set_vf_multicast_promisc(uint16_t port, uint16_t vf_id, uint8_t on);
+int vfd_bnxt_set_vf_mac_addr(uint16_t port, uint16_t vf_id, struct ether_addr *mac_addr);
+int vfd_bnxt_set_vf_default_mac_addr( uint16_t port_id, uint16_t vf_id, struct ether_addr *mac_addr );
+int vfd_bnxt_set_vf_vlan_stripq(uint16_t port, uint16_t vf, uint8_t on);
+int vfd_bnxt_set_vf_vlan_insert(uint16_t port, uint16_t vf_id, uint16_t vlan_id);
+int vfd_bnxt_set_vf_broadcast(uint16_t port, uint16_t vf_id, uint8_t on);
+int vfd_bnxt_set_vf_vlan_tag(uint16_t port, uint16_t vf_id, uint8_t on);
+int vfd_bnxt_set_vf_vlan_filter(uint16_t port, uint16_t vlan_id, uint64_t vf_mask, uint8_t on);
+int vfd_bnxt_get_vf_stats(uint16_t port, uint16_t vf_id, struct rte_eth_stats *stats);
+int vfd_bnxt_reset_vf_stats(uint16_t port, uint16_t vf_id);
 
-int vfd_bnxt_vf_msb_event_callback(uint8_t port_id, enum rte_eth_event_type type, void *param, void* data );
+int vfd_bnxt_vf_msb_event_callback(uint16_t port_id, enum rte_eth_event_type type, void *param, void* data );
 
-int vfd_bnxt_allow_untagged(uint8_t port, uint16_t vf_id, uint8_t on);
+int vfd_bnxt_allow_untagged(uint16_t port, uint16_t vf_id, uint8_t on);
 
-int vfd_bnxt_set_all_queues_drop_en(uint8_t port_id, uint8_t on);
-uint32_t vfd_bnxt_get_pf_spoof_stats(uint8_t port_id);
-uint32_t vfd_bnxt_get_vf_spoof_stats(uint8_t port_id, uint16_t vf_id);
-int vfd_bnxt_is_rx_queue_on(uint8_t port_id, uint16_t vf_id, int* mcounter);
-void vfd_bnxt_set_rx_drop(uint8_t port_id, uint16_t vf_id, int state);
-void vfd_bnxt_set_split_erop(uint8_t port_id, uint16_t vf_id, int state);
-int vfd_bnxt_dump_all_vlans(uint8_t port_id);
+int vfd_bnxt_set_all_queues_drop_en(uint16_t port_id, uint8_t on);
+uint32_t vfd_bnxt_get_pf_spoof_stats(uint16_t port_id);
+uint32_t vfd_bnxt_get_vf_spoof_stats(uint16_t port_id, uint16_t vf_id);
+int vfd_bnxt_is_rx_queue_on(uint16_t port_id, uint16_t vf_id, int* mcounter);
+void vfd_bnxt_set_rx_drop(uint16_t port_id, uint16_t vf_id, int state);
+void vfd_bnxt_set_split_erop(uint16_t port_id, uint16_t vf_id, int state);
+int vfd_bnxt_dump_all_vlans(uint16_t port_id);
 
 #endif

--- a/src/vfd/vfd_i40e.c
+++ b/src/vfd/vfd_i40e.c
@@ -2,7 +2,7 @@
 #include "sriov.h"
 
 int  
-vfd_i40e_ping_vfs(uint8_t port_id, int16_t vf_id)
+vfd_i40e_ping_vfs(uint16_t port_id, int16_t vf_id)
 {
 	int diag = 0;
 	int i;
@@ -33,7 +33,7 @@ vfd_i40e_ping_vfs(uint8_t port_id, int16_t vf_id)
 
 
 int 
-vfd_i40e_set_vf_mac_anti_spoof(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_i40e_set_vf_mac_anti_spoof(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 	int diag = rte_pmd_i40e_set_vf_mac_anti_spoof(port_id, vf_id, on);
 	if (diag < 0) {
@@ -47,7 +47,7 @@ vfd_i40e_set_vf_mac_anti_spoof(uint8_t port_id, uint16_t vf_id, uint8_t on)
 
 
 int 
-vfd_i40e_set_vf_vlan_anti_spoof(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_i40e_set_vf_vlan_anti_spoof(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 	int diag = rte_pmd_i40e_set_vf_vlan_anti_spoof(port_id, vf_id, on);
 	if (diag < 0) {
@@ -61,7 +61,7 @@ vfd_i40e_set_vf_vlan_anti_spoof(uint8_t port_id, uint16_t vf_id, uint8_t on)
 
 
 int 
-vfd_i40e_set_tx_loopback(uint8_t port_id, uint8_t on)
+vfd_i40e_set_tx_loopback(uint16_t port_id, uint8_t on)
 {
 	int diag = rte_pmd_i40e_set_tx_loopback(port_id, on);
 	if (diag < 0) {
@@ -75,7 +75,7 @@ vfd_i40e_set_tx_loopback(uint8_t port_id, uint8_t on)
 
 
 int 
-vfd_i40e_set_vf_unicast_promisc(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_i40e_set_vf_unicast_promisc(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 	int diag = rte_pmd_i40e_set_vf_unicast_promisc(port_id, vf_id, on);
 	if (diag < 0) {
@@ -89,7 +89,7 @@ vfd_i40e_set_vf_unicast_promisc(uint8_t port_id, uint16_t vf_id, uint8_t on)
 
 
 int 
-vfd_i40e_set_vf_multicast_promisc(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_i40e_set_vf_multicast_promisc(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 	int diag = rte_pmd_i40e_set_vf_multicast_promisc(port_id, vf_id, on);
 	if (diag < 0) {
@@ -103,7 +103,7 @@ vfd_i40e_set_vf_multicast_promisc(uint8_t port_id, uint16_t vf_id, uint8_t on)
 
 
 int 
-vfd_i40e_set_vf_mac_addr(uint8_t port_id, uint16_t vf_id,  __attribute__((__unused__)) struct ether_addr *mac_addr)
+vfd_i40e_set_vf_mac_addr(uint16_t port_id, uint16_t vf_id,  __attribute__((__unused__)) struct ether_addr *mac_addr)
 {
 	/* FIXME looks like this isn't working for FVL25 ? */
 	int diag = rte_eth_dev_mac_addr_add( port_id, mac_addr, vf_id );
@@ -125,7 +125,7 @@ vfd_i40e_set_vf_mac_addr(uint8_t port_id, uint16_t vf_id,  __attribute__((__unus
 	we call it only once during VFd startup
 */
 int 
-vfd_i40e_set_vf_default_mac_addr(uint8_t port_id, uint16_t vf, struct ether_addr *mac_addr ) {
+vfd_i40e_set_vf_default_mac_addr(uint16_t port_id, uint16_t vf, struct ether_addr *mac_addr ) {
 	int state = 0;
 	struct vf_s* vfp;
 
@@ -149,7 +149,7 @@ vfd_i40e_set_vf_default_mac_addr(uint8_t port_id, uint16_t vf, struct ether_addr
 }
 
 int 
-vfd_i40e_set_vf_vlan_stripq(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_i40e_set_vf_vlan_stripq(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 	int diag = rte_pmd_i40e_set_vf_vlan_stripq(port_id, vf_id, on);
 	if (diag < 0) {
@@ -163,7 +163,7 @@ vfd_i40e_set_vf_vlan_stripq(uint8_t port_id, uint16_t vf_id, uint8_t on)
 
 
 int 
-vfd_i40e_set_vf_vlan_insert(uint8_t port_id, uint16_t vf_id, uint16_t vlan_id)
+vfd_i40e_set_vf_vlan_insert(uint16_t port_id, uint16_t vf_id, uint16_t vlan_id)
 {
 	int diag = rte_pmd_i40e_set_vf_vlan_insert(port_id, vf_id, vlan_id);
 	if (diag < 0) {
@@ -177,7 +177,7 @@ vfd_i40e_set_vf_vlan_insert(uint8_t port_id, uint16_t vf_id, uint16_t vlan_id)
 
 
 int 
-vfd_i40e_set_vf_broadcast(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_i40e_set_vf_broadcast(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 	int diag = rte_pmd_i40e_set_vf_broadcast(port_id, vf_id, on);
 	if (diag < 0) {
@@ -191,7 +191,7 @@ vfd_i40e_set_vf_broadcast(uint8_t port_id, uint16_t vf_id, uint8_t on)
 
 
 int 
-vfd_i40e_allow_untagged(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_i40e_allow_untagged(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {	
 	int diag = 0;
 	//int diag = rte_pmd_i40e_set_vf_vlan_untag_drop(port_id, vf_id, !on);  // don't allow untagged
@@ -206,7 +206,7 @@ vfd_i40e_allow_untagged(uint8_t port_id, uint16_t vf_id, uint8_t on)
 
 
 int 
-vfd_i40e_set_vf_vlan_filter(uint8_t port_id, uint16_t vlan_id, uint64_t vf_mask, uint8_t on)
+vfd_i40e_set_vf_vlan_filter(uint16_t port_id, uint16_t vlan_id, uint64_t vf_mask, uint8_t on)
 {
 	int diag = rte_pmd_i40e_set_vf_vlan_filter(port_id, vlan_id, vf_mask, on);
 	if (diag < 0) {
@@ -220,7 +220,7 @@ vfd_i40e_set_vf_vlan_filter(uint8_t port_id, uint16_t vlan_id, uint64_t vf_mask,
 
 
 int 
-vfd_i40e_get_vf_stats(uint8_t port_id, uint16_t vf_id, struct rte_eth_stats *stats)
+vfd_i40e_get_vf_stats(uint16_t port_id, uint16_t vf_id, struct rte_eth_stats *stats)
 {
 	int diag = rte_pmd_i40e_get_vf_stats(port_id, vf_id, stats);
 	if (diag < 0) {
@@ -238,7 +238,7 @@ vfd_i40e_get_vf_stats(uint8_t port_id, uint16_t vf_id, struct rte_eth_stats *sta
 
 
 int 
-vfd_i40e_reset_vf_stats(uint8_t port_id, uint16_t vf_id)
+vfd_i40e_reset_vf_stats(uint16_t port_id, uint16_t vf_id)
 {
 	int diag = rte_pmd_i40e_reset_vf_stats(port_id, vf_id);
 	if (diag < 0) {
@@ -252,7 +252,7 @@ vfd_i40e_reset_vf_stats(uint8_t port_id, uint16_t vf_id)
 
 
 int 
-vfd_i40e_set_all_queues_drop_en(uint8_t port_id, uint8_t on)
+vfd_i40e_set_all_queues_drop_en(uint16_t port_id, uint8_t on)
 {
 	bleat_printf( 3, "vfd_i40e_set_all_queues_drop_en not implemented: port_id=%d, on=%d", port_id, on);
 
@@ -336,7 +336,7 @@ struct i40e_virtchnl_promisc_info {
 
 
 int
-vfd_i40e_vf_msb_event_callback(uint8_t port_id, enum rte_eth_event_type type, void *data, void *param) {
+vfd_i40e_vf_msb_event_callback(uint16_t port_id, enum rte_eth_event_type type, void *data, void *param) {
 
 	struct vf_s* vfp;
 	struct rte_pmd_ixgbe_mb_event_param *p;
@@ -606,7 +606,7 @@ vfd_i40e_vf_msb_event_callback(uint8_t port_id, enum rte_eth_event_type type, vo
 }
 
 uint32_t 
-vfd_i40e_get_pf_spoof_stats(uint8_t port_id)
+vfd_i40e_get_pf_spoof_stats(uint16_t port_id)
 {
 	uint32_t spoofed = 0;
 	struct rte_eth_stats stats;
@@ -631,7 +631,7 @@ vfd_i40e_get_pf_spoof_stats(uint8_t port_id)
 
 
 uint32_t 
-vfd_i40e_get_vf_spoof_stats(uint8_t port_id, uint16_t vf_id)
+vfd_i40e_get_vf_spoof_stats(uint16_t port_id, uint16_t vf_id)
 {
 	/* not implemented */
 	bleat_printf( 3, "vfd_i40e_get_vf_spoof_stats not implemented: port_id=%d, on=%d", port_id, vf_id);
@@ -641,7 +641,7 @@ vfd_i40e_get_vf_spoof_stats(uint8_t port_id, uint16_t vf_id)
 
 
 int 
-vfd_i40e_is_rx_queue_on(uint8_t port_id, uint16_t vf_id, __attribute__((__unused__)) int* mcounter)
+vfd_i40e_is_rx_queue_on(uint16_t port_id, uint16_t vf_id, __attribute__((__unused__)) int* mcounter)
 {
 	struct vf_s* vfp;
 	vfp = suss_vf( port_id, vf_id );		// find our vf structure matching this vf
@@ -664,7 +664,7 @@ vfd_i40e_is_rx_queue_on(uint8_t port_id, uint16_t vf_id, __attribute__((__unused
 
 
 void 
-vfd_i40e_set_pfrx_drop(uint8_t port_id,  __attribute__((__unused__)) int state)
+vfd_i40e_set_pfrx_drop(uint16_t port_id,  __attribute__((__unused__)) int state)
 {
 	/* TODO */
 	bleat_printf( 0, "vfd_i40e_set_pfrx_drop(): not implementede for port %d", port_id);
@@ -672,7 +672,7 @@ vfd_i40e_set_pfrx_drop(uint8_t port_id,  __attribute__((__unused__)) int state)
 
 
 void 
-vfd_i40e_set_rx_drop(uint8_t port_id, uint16_t vf_id, __attribute__((__unused__)) int state)
+vfd_i40e_set_rx_drop(uint16_t port_id, uint16_t vf_id, __attribute__((__unused__)) int state)
 {
 	/* TODO */
 	bleat_printf( 0, "vfd_i40e_set_pfrx_drop(): not implemented for port=%d, vf=%d", port_id, vf_id);
@@ -680,7 +680,7 @@ vfd_i40e_set_rx_drop(uint8_t port_id, uint16_t vf_id, __attribute__((__unused__)
 
 
 void 
-vfd_i40e_set_split_erop(uint8_t port_id, uint16_t vf_id, __attribute__((__unused__)) int state)
+vfd_i40e_set_split_erop(uint16_t port_id, uint16_t vf_id, __attribute__((__unused__)) int state)
 {
 	/* TODO */
 	bleat_printf( 0, "vfd_i40e_set_split_erop(): not implemented for port=%d, vf=%d", port_id, vf_id );	
@@ -688,7 +688,7 @@ vfd_i40e_set_split_erop(uint8_t port_id, uint16_t vf_id, __attribute__((__unused
 
 
 int 
-vfd_i40e_get_split_ctlreg(uint8_t port_id, uint16_t vf_id)
+vfd_i40e_get_split_ctlreg(uint16_t port_id, uint16_t vf_id)
 {
 	/* not implemented */
 	bleat_printf( 3, "vfd_i40e_get_split_ctlreg not implemented: port_id=%d, vd_id=%d", port_id, vf_id);
@@ -698,7 +698,7 @@ vfd_i40e_get_split_ctlreg(uint8_t port_id, uint16_t vf_id)
 }
 
 int 
-vfd_i40e_dump_all_vlans(uint8_t port_id)
+vfd_i40e_dump_all_vlans(uint16_t port_id)
 {
 	/* TODO */
 	bleat_printf( 0, "vfd_i40e_dump_all_vlans(): not implemented for port=%d", port_id );	

--- a/src/vfd/vfd_i40e.h
+++ b/src/vfd/vfd_i40e.h
@@ -45,30 +45,30 @@ enum i40e_virtchnl_ops {
 	
 // ------------- prototypes ----------------------------------------------
 
-int vfd_i40e_ping_vfs(uint8_t port, int16_t vf);
-int vfd_i40e_set_vf_mac_anti_spoof(uint8_t port, uint16_t vf_id, uint8_t on); 
-int vfd_i40e_set_vf_vlan_anti_spoof(uint8_t port, uint16_t vf_id, uint8_t on);
-int vfd_i40e_set_tx_loopback(uint8_t port, uint8_t on);
-int vfd_i40e_set_vf_unicast_promisc(uint8_t port, uint16_t vf_id, uint8_t on);
-int vfd_i40e_set_vf_multicast_promisc(uint8_t port, uint16_t vf_id, uint8_t on);
-int vfd_i40e_set_vf_mac_addr(uint8_t port, uint16_t vf_id, struct ether_addr *mac_addr);
-int vfd_i40e_set_vf_default_mac_addr(uint8_t port_id, uint16_t vf, struct ether_addr *mac_addr );
-int vfd_i40e_set_vf_vlan_stripq(uint8_t port, uint16_t vf, uint8_t on);
-int vfd_i40e_set_vf_vlan_insert(uint8_t port, uint16_t vf_id, uint16_t vlan_id);
-int vfd_i40e_set_vf_broadcast(uint8_t port, uint16_t vf_id, uint8_t on);
-int vfd_i40e_allow_untagged(uint8_t port, uint16_t vf_id, uint8_t on);
-int vfd_i40e_set_vf_vlan_filter(uint8_t port, uint16_t vlan_id, uint64_t vf_mask, uint8_t on);
-int vfd_i40e_get_vf_stats(uint8_t port, uint16_t vf_id, struct rte_eth_stats *stats);
-int vfd_i40e_reset_vf_stats(uint8_t port, uint16_t vf_id);
-int vfd_i40e_set_all_queues_drop_en(uint8_t port_id, uint8_t on);
-int vfd_i40e_vf_msb_event_callback(uint8_t port_id, enum rte_eth_event_type type, void *param, void *data);
-uint32_t vfd_i40e_get_pf_spoof_stats(uint8_t port_id);
-uint32_t vfd_i40e_get_vf_spoof_stats(uint8_t port_id, uint16_t vf_id);
-int vfd_i40e_is_rx_queue_on(uint8_t port_id, uint16_t vf_id, int* mcounter);
-void vfd_i40e_set_pfrx_drop(uint8_t port_id, int state );
-void vfd_i40e_set_rx_drop(uint8_t port_id, uint16_t vf_id, int state);
-void vfd_i40e_set_split_erop(uint8_t port_id, uint16_t vf_id, int state);
-int vfd_i40e_get_split_ctlreg(uint8_t port_id, uint16_t vf_id);
-int vfd_i40e_dump_all_vlans(uint8_t port_id);
+int vfd_i40e_ping_vfs(uint16_t port, int16_t vf);
+int vfd_i40e_set_vf_mac_anti_spoof(uint16_t port, uint16_t vf_id, uint8_t on); 
+int vfd_i40e_set_vf_vlan_anti_spoof(uint16_t port, uint16_t vf_id, uint8_t on);
+int vfd_i40e_set_tx_loopback(uint16_t port, uint8_t on);
+int vfd_i40e_set_vf_unicast_promisc(uint16_t port, uint16_t vf_id, uint8_t on);
+int vfd_i40e_set_vf_multicast_promisc(uint16_t port, uint16_t vf_id, uint8_t on);
+int vfd_i40e_set_vf_mac_addr(uint16_t port, uint16_t vf_id, struct ether_addr *mac_addr);
+int vfd_i40e_set_vf_default_mac_addr(uint16_t port_id, uint16_t vf, struct ether_addr *mac_addr );
+int vfd_i40e_set_vf_vlan_stripq(uint16_t port, uint16_t vf, uint8_t on);
+int vfd_i40e_set_vf_vlan_insert(uint16_t port, uint16_t vf_id, uint16_t vlan_id);
+int vfd_i40e_set_vf_broadcast(uint16_t port, uint16_t vf_id, uint8_t on);
+int vfd_i40e_allow_untagged(uint16_t port, uint16_t vf_id, uint8_t on);
+int vfd_i40e_set_vf_vlan_filter(uint16_t port, uint16_t vlan_id, uint64_t vf_mask, uint8_t on);
+int vfd_i40e_get_vf_stats(uint16_t port, uint16_t vf_id, struct rte_eth_stats *stats);
+int vfd_i40e_reset_vf_stats(uint16_t port, uint16_t vf_id);
+int vfd_i40e_set_all_queues_drop_en(uint16_t port_id, uint8_t on);
+int vfd_i40e_vf_msb_event_callback(uint16_t port_id, enum rte_eth_event_type type, void *param, void *data);
+uint32_t vfd_i40e_get_pf_spoof_stats(uint16_t port_id);
+uint32_t vfd_i40e_get_vf_spoof_stats(uint16_t port_id, uint16_t vf_id);
+int vfd_i40e_is_rx_queue_on(uint16_t port_id, uint16_t vf_id, int* mcounter);
+void vfd_i40e_set_pfrx_drop(uint16_t port_id, int state );
+void vfd_i40e_set_rx_drop(uint16_t port_id, uint16_t vf_id, int state);
+void vfd_i40e_set_split_erop(uint16_t port_id, uint16_t vf_id, int state);
+int vfd_i40e_get_split_ctlreg(uint16_t port_id, uint16_t vf_id);
+int vfd_i40e_dump_all_vlans(uint16_t port_id);
 
 #endif

--- a/src/vfd/vfd_ixgbe.c
+++ b/src/vfd/vfd_ixgbe.c
@@ -2,7 +2,7 @@
 #include "sriov.h"
 
 int  
-vfd_ixgbe_ping_vfs( __attribute__((__unused__)) uint8_t port_id,  __attribute__((__unused__)) int16_t vf_id)
+vfd_ixgbe_ping_vfs( __attribute__((__unused__)) uint16_t port_id,  __attribute__((__unused__)) int16_t vf_id)
 {
 	int diag = 0;
 	int i;
@@ -33,7 +33,7 @@ vfd_ixgbe_ping_vfs( __attribute__((__unused__)) uint8_t port_id,  __attribute__(
 
 
 int 
-vfd_ixgbe_set_vf_mac_anti_spoof(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_ixgbe_set_vf_mac_anti_spoof(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 	int diag = rte_pmd_ixgbe_set_vf_mac_anti_spoof(port_id, vf_id, on);
 	if (diag < 0) {
@@ -47,7 +47,7 @@ vfd_ixgbe_set_vf_mac_anti_spoof(uint8_t port_id, uint16_t vf_id, uint8_t on)
 
 
 int 
-vfd_ixgbe_set_vf_vlan_anti_spoof(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_ixgbe_set_vf_vlan_anti_spoof(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 	int diag = rte_pmd_ixgbe_set_vf_vlan_anti_spoof(port_id, vf_id, on);
 	if (diag < 0) {
@@ -61,7 +61,7 @@ vfd_ixgbe_set_vf_vlan_anti_spoof(uint8_t port_id, uint16_t vf_id, uint8_t on)
 
 
 int 
-vfd_ixgbe_set_tx_loopback(uint8_t port_id, uint8_t on)
+vfd_ixgbe_set_tx_loopback(uint16_t port_id, uint8_t on)
 {
 	int diag = rte_pmd_ixgbe_set_tx_loopback(port_id, on);
 	if (diag < 0) {
@@ -75,7 +75,7 @@ vfd_ixgbe_set_tx_loopback(uint8_t port_id, uint8_t on)
 
 
 int 
-vfd_ixgbe_set_vf_unicast_promisc(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_ixgbe_set_vf_unicast_promisc(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 	int diag = rte_pmd_ixgbe_set_vf_rxmode(port_id, vf_id, ETH_VMDQ_ACCEPT_HASH_UC,(uint8_t) on);
 	if (diag < 0) {
@@ -89,7 +89,7 @@ vfd_ixgbe_set_vf_unicast_promisc(uint8_t port_id, uint16_t vf_id, uint8_t on)
 
 
 int 
-vfd_ixgbe_set_vf_multicast_promisc(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_ixgbe_set_vf_multicast_promisc(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 	int diag = rte_pmd_ixgbe_set_vf_rxmode(port_id, vf_id, ETH_VMDQ_ACCEPT_MULTICAST,(uint8_t) on);
 	if (diag < 0) {
@@ -110,7 +110,7 @@ vfd_ixgbe_set_vf_multicast_promisc(uint8_t port_id, uint16_t vf_id, uint8_t on)
 	should be made after all calls to this function have been made. 
 */
 int 
-vfd_ixgbe_set_vf_mac_addr(uint8_t port_id, uint16_t vf_id, struct ether_addr *mac_addr)
+vfd_ixgbe_set_vf_mac_addr(uint16_t port_id, uint16_t vf_id, struct ether_addr *mac_addr)
 {
  	int diag = rte_eth_dev_mac_addr_add( port_id, mac_addr, vf_id );			// add to whitelist
 	if (diag < 0) {
@@ -142,7 +142,7 @@ int vfd_ixgbe_set_vf_default_mac_addr( portid_t port_id, uint16_t vf, struct eth
 
 
 int 
-vfd_ixgbe_set_vf_vlan_stripq(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_ixgbe_set_vf_vlan_stripq(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 	int diag = rte_pmd_ixgbe_set_vf_vlan_stripq(port_id, vf_id, on);
 	if (diag < 0) {
@@ -156,7 +156,7 @@ vfd_ixgbe_set_vf_vlan_stripq(uint8_t port_id, uint16_t vf_id, uint8_t on)
 
 
 int 
-vfd_ixgbe_set_vf_vlan_insert(uint8_t port_id, uint16_t vf_id, uint16_t vlan_id)
+vfd_ixgbe_set_vf_vlan_insert(uint16_t port_id, uint16_t vf_id, uint16_t vlan_id)
 {
 	int diag = rte_pmd_ixgbe_set_vf_vlan_insert(port_id, vf_id, vlan_id);
 	if (diag < 0) {
@@ -170,7 +170,7 @@ vfd_ixgbe_set_vf_vlan_insert(uint8_t port_id, uint16_t vf_id, uint16_t vlan_id)
 
 
 int 
-vfd_ixgbe_set_vf_broadcast(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_ixgbe_set_vf_broadcast(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 	int diag = rte_pmd_ixgbe_set_vf_rxmode(port_id, vf_id, ETH_VMDQ_ACCEPT_BROADCAST,(uint8_t) on);
 	if (diag < 0) {
@@ -184,7 +184,7 @@ vfd_ixgbe_set_vf_broadcast(uint8_t port_id, uint16_t vf_id, uint8_t on)
 
 
 int 
-vfd_ixgbe_allow_untagged(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_ixgbe_allow_untagged(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 	
 	uint16_t rx_mode = 0;
@@ -202,7 +202,7 @@ vfd_ixgbe_allow_untagged(uint8_t port_id, uint16_t vf_id, uint8_t on)
 
 
 int 
-vfd_ixgbe_set_vf_vlan_filter(uint8_t port_id, uint16_t vlan_id, uint64_t vf_mask, uint8_t on)
+vfd_ixgbe_set_vf_vlan_filter(uint16_t port_id, uint16_t vlan_id, uint64_t vf_mask, uint8_t on)
 {
 	int diag = rte_pmd_ixgbe_set_vf_vlan_filter(port_id, vlan_id, vf_mask, on);
 	if (diag < 0) {
@@ -216,7 +216,7 @@ vfd_ixgbe_set_vf_vlan_filter(uint8_t port_id, uint16_t vlan_id, uint64_t vf_mask
 
 
 int 
-vfd_ixgbe_get_vf_stats(uint8_t port_id, uint16_t vf_id, struct rte_eth_stats *stats)
+vfd_ixgbe_get_vf_stats(uint16_t port_id, uint16_t vf_id, struct rte_eth_stats *stats)
 {
 	int diag = 0;
 	/* not implemented in DPDK yet */
@@ -250,7 +250,7 @@ vfd_ixgbe_get_vf_stats(uint8_t port_id, uint16_t vf_id, struct rte_eth_stats *st
 
 
 int 
-vfd_ixgbe_reset_vf_stats(uint8_t port_id, uint16_t vf_id)
+vfd_ixgbe_reset_vf_stats(uint16_t port_id, uint16_t vf_id)
 {
 	int diag = 0;
 	
@@ -267,7 +267,7 @@ vfd_ixgbe_reset_vf_stats(uint8_t port_id, uint16_t vf_id)
 
 
 int 
-vfd_ixgbe_set_vf_rate_limit(uint8_t port_id, uint16_t vf_id, uint16_t tx_rate, uint64_t q_msk)
+vfd_ixgbe_set_vf_rate_limit(uint16_t port_id, uint16_t vf_id, uint16_t tx_rate, uint64_t q_msk)
 {
 	int diag = rte_pmd_ixgbe_set_vf_rate_limit(port_id, vf_id, tx_rate, q_msk);
 	if (diag < 0) {
@@ -281,7 +281,7 @@ vfd_ixgbe_set_vf_rate_limit(uint8_t port_id, uint16_t vf_id, uint16_t tx_rate, u
 
 
 int 
-vfd_ixgbe_set_all_queues_drop_en(uint8_t port_id, uint8_t on)
+vfd_ixgbe_set_all_queues_drop_en(uint16_t port_id, uint8_t on)
 {
 	int diag = rte_pmd_ixgbe_set_all_queues_drop_en(port_id, on);
 	if (diag < 0) {
@@ -300,7 +300,7 @@ vfd_ixgbe_set_all_queues_drop_en(uint8_t port_id, uint8_t on)
 	NULL (hard set in their code).
 */
 int
-vfd_ixgbe_vf_msb_event_callback(uint8_t port_id, enum rte_eth_event_type type, void *data, void* param ) {
+vfd_ixgbe_vf_msb_event_callback(uint16_t port_id, enum rte_eth_event_type type, void *data, void* param ) {
 
 	struct rte_pmd_ixgbe_mb_event_param *p;
 	uint16_t vf;
@@ -465,7 +465,7 @@ vfd_ixgbe_vf_msb_event_callback(uint8_t port_id, enum rte_eth_event_type type, v
 
 
 uint32_t 
-vfd_ixgbe_get_pf_spoof_stats(uint8_t port_id)
+vfd_ixgbe_get_pf_spoof_stats(uint16_t port_id)
 {
 	bleat_printf( 3, "vfd_ixgbe_get_pf_spoof_stats: port_id=%d", port_id);
 	return port_pci_reg_read(port_id, 0x08780);
@@ -473,7 +473,7 @@ vfd_ixgbe_get_pf_spoof_stats(uint8_t port_id)
 
 
 uint32_t 
-vfd_ixgbe_get_vf_spoof_stats(__attribute__((__unused__)) uint8_t port_id, __attribute__((__unused__)) uint16_t vf_id)
+vfd_ixgbe_get_vf_spoof_stats(__attribute__((__unused__)) uint16_t port_id, __attribute__((__unused__)) uint16_t vf_id)
 {
 	/* not implemented */
 	bleat_printf( 3, "vfd_ixgbe_get_vf_spoof_stats not implemented: port_id=%d, vf_id=%d", port_id, vf_id);
@@ -481,7 +481,7 @@ vfd_ixgbe_get_vf_spoof_stats(__attribute__((__unused__)) uint8_t port_id, __attr
 }
 
 void 
-vfd_ixgbe_disable_default_pool(uint8_t port_id)
+vfd_ixgbe_disable_default_pool(uint16_t port_id)
 {
 	uint32_t ctrl = port_pci_reg_read(port_id, IXGBE_VT_CTL);
 	ctrl |= IXGBE_VT_CTL_DIS_DEFPL;
@@ -491,7 +491,7 @@ vfd_ixgbe_disable_default_pool(uint8_t port_id)
 
 
 int 
-vfd_ixgbe_is_rx_queue_on(uint8_t port_id, uint16_t vf_id, int* mcounter)
+vfd_ixgbe_is_rx_queue_on(uint16_t port_id, uint16_t vf_id, int* mcounter)
 {
 	int queue;						// queue to set (0-max-queues)
 	uint32_t reg_off;				// control register address
@@ -538,7 +538,7 @@ vfd_ixgbe_is_rx_queue_on(uint8_t port_id, uint16_t vf_id, int* mcounter)
 
 
 void 
-vfd_ixgbe_set_pfrx_drop(uint8_t port_id, int state)
+vfd_ixgbe_set_pfrx_drop(uint16_t port_id, int state)
 {
 	uint16_t qstart;			// point where the queue starts (1 past the last VF)
 	int          i;
@@ -569,7 +569,7 @@ vfd_ixgbe_set_pfrx_drop(uint8_t port_id, int state)
 
 
 void 
-vfd_ixgbe_set_rx_drop(uint8_t port_id, uint16_t vf_id, int state)
+vfd_ixgbe_set_rx_drop(uint16_t port_id, uint16_t vf_id, int state)
 {
 	int          i;
 	uint32_t reg_off;
@@ -593,7 +593,7 @@ vfd_ixgbe_set_rx_drop(uint8_t port_id, uint16_t vf_id, int state)
 
 
 void 
-vfd_ixgbe_set_split_erop(uint8_t port_id, uint16_t vf_id, int state)
+vfd_ixgbe_set_split_erop(uint16_t port_id, uint16_t vf_id, int state)
 {
 	uint32_t reg_off = 0x01014; 							// split receive control regs (pg598)
 	uint32_t reg_value;
@@ -625,7 +625,7 @@ vfd_ixgbe_set_split_erop(uint8_t port_id, uint16_t vf_id, int state)
 
 
 int 
-vfd_ixgbe_get_split_ctlreg(uint8_t port_id, uint16_t vf_id)
+vfd_ixgbe_get_split_ctlreg(uint16_t port_id, uint16_t vf_id)
 {
 	uint32_t reg_off = 0x01014; 	// split receive control regs (pg598)
 	int queue;						// the first queue for the vf (TODO: expand this to accept a queue 0-max_qpp)
@@ -643,7 +643,7 @@ vfd_ixgbe_get_split_ctlreg(uint8_t port_id, uint16_t vf_id)
 
 
 int 
-vfd_ixgbe_dump_all_vlans(uint8_t port_id)
+vfd_ixgbe_dump_all_vlans(uint16_t port_id)
 {
 	uint32_t res;
 	uint32_t ix;

--- a/src/vfd/vfd_ixgbe.h
+++ b/src/vfd/vfd_ixgbe.h
@@ -9,39 +9,39 @@
 
 // ------------- prototypes ----------------------------------------------
 
-int vfd_ixgbe_ping_vfs(uint8_t port, int16_t vf);
-int vfd_ixgbe_set_vf_mac_anti_spoof(uint8_t port, uint16_t vf_id, uint8_t on); 
-int vfd_ixgbe_set_vf_vlan_anti_spoof(uint8_t port, uint16_t vf_id, uint8_t on);
-int vfd_ixgbe_set_tx_loopback(uint8_t port, uint8_t on);
-int vfd_ixgbe_set_vf_unicast_promisc(uint8_t port, uint16_t vf_id, uint8_t on);
-int vfd_ixgbe_set_vf_multicast_promisc(uint8_t port, uint16_t vf_id, uint8_t on);
-int vfd_ixgbe_set_vf_mac_addr(uint8_t port, uint16_t vf_id, struct ether_addr *mac_addr);
-int vfd_ixgbe_set_vf_default_mac_addr( uint8_t port_id, uint16_t vf, struct ether_addr *mac_addr );
-int vfd_ixgbe_set_vf_vlan_stripq(uint8_t port, uint16_t vf, uint8_t on);
-int vfd_ixgbe_set_vf_vlan_insert(uint8_t port, uint16_t vf_id, uint16_t vlan_id);
-int vfd_ixgbe_set_vf_broadcast(uint8_t port, uint16_t vf_id, uint8_t on);
-int vfd_ixgbe_allow_untagged(uint8_t port, uint16_t vf_id, uint8_t on);
-int vfd_ixgbe_set_vf_vlan_filter(uint8_t port, uint16_t vlan_id, uint64_t vf_mask, uint8_t on);
-int vfd_ixgbe_get_vf_stats(uint8_t port, uint16_t vf_id, struct rte_eth_stats *stats);
-int vfd_ixgbe_reset_vf_stats(uint8_t port, uint16_t vf_id);
-int vfd_ixgbe_set_vf_rate_limit(uint8_t port_id, uint16_t vf_id, uint16_t tx_rate, uint64_t q_msk);
-int vfd_ixgbe_set_all_queues_drop_en(uint8_t port, uint8_t on);
+int vfd_ixgbe_ping_vfs(uint16_t port, int16_t vf);
+int vfd_ixgbe_set_vf_mac_anti_spoof(uint16_t port, uint16_t vf_id, uint8_t on); 
+int vfd_ixgbe_set_vf_vlan_anti_spoof(uint16_t port, uint16_t vf_id, uint8_t on);
+int vfd_ixgbe_set_tx_loopback(uint16_t port, uint8_t on);
+int vfd_ixgbe_set_vf_unicast_promisc(uint16_t port, uint16_t vf_id, uint8_t on);
+int vfd_ixgbe_set_vf_multicast_promisc(uint16_t port, uint16_t vf_id, uint8_t on);
+int vfd_ixgbe_set_vf_mac_addr(uint16_t port, uint16_t vf_id, struct ether_addr *mac_addr);
+int vfd_ixgbe_set_vf_default_mac_addr( uint16_t port_id, uint16_t vf, struct ether_addr *mac_addr );
+int vfd_ixgbe_set_vf_vlan_stripq(uint16_t port, uint16_t vf, uint8_t on);
+int vfd_ixgbe_set_vf_vlan_insert(uint16_t port, uint16_t vf_id, uint16_t vlan_id);
+int vfd_ixgbe_set_vf_broadcast(uint16_t port, uint16_t vf_id, uint8_t on);
+int vfd_ixgbe_allow_untagged(uint16_t port, uint16_t vf_id, uint8_t on);
+int vfd_ixgbe_set_vf_vlan_filter(uint16_t port, uint16_t vlan_id, uint64_t vf_mask, uint8_t on);
+int vfd_ixgbe_get_vf_stats(uint16_t port, uint16_t vf_id, struct rte_eth_stats *stats);
+int vfd_ixgbe_reset_vf_stats(uint16_t port, uint16_t vf_id);
+int vfd_ixgbe_set_vf_rate_limit(uint16_t port_id, uint16_t vf_id, uint16_t tx_rate, uint64_t q_msk);
+int vfd_ixgbe_set_all_queues_drop_en(uint16_t port, uint8_t on);
 
-int vfd_ixgbe_vf_msb_event_callback(uint8_t port_id, enum rte_eth_event_type type, void *param, void *data);
-
-
-uint32_t vfd_ixgbe_get_pf_spoof_stats(uint8_t port_id);
-uint32_t vfd_ixgbe_get_vf_spoof_stats(uint8_t port_id, uint16_t vf_id);
-
-void vfd_ixgbe_disable_default_pool(uint8_t port_id);
-int vfd_ixgbe_is_rx_queue_on(uint8_t port_id, uint16_t vf_id, int* mcounter);
+int vfd_ixgbe_vf_msb_event_callback(uint16_t port_id, enum rte_eth_event_type type, void *data, void* param );
 
 
-void vfd_ixgbe_set_pfrx_drop(uint8_t port_id, int state );
-void vfd_ixgbe_set_rx_drop(uint8_t port_id, uint16_t vf_id, int state);
-void vfd_ixgbe_set_split_erop(uint8_t port_id, uint16_t vf_id, int state);
-int vfd_ixgbe_get_split_ctlreg(uint8_t port_id, uint16_t vf_id);
-int vfd_ixgbe_dump_all_vlans(uint8_t port_id);
+uint32_t vfd_ixgbe_get_pf_spoof_stats(uint16_t port_id);
+uint32_t vfd_ixgbe_get_vf_spoof_stats(uint16_t port_id, uint16_t vf_id);
+
+void vfd_ixgbe_disable_default_pool(uint16_t port_id);
+int vfd_ixgbe_is_rx_queue_on(uint16_t port_id, uint16_t vf_id, int* mcounter);
+
+
+void vfd_ixgbe_set_pfrx_drop(uint16_t port_id, int state );
+void vfd_ixgbe_set_rx_drop(uint16_t port_id, uint16_t vf_id, int state);
+void vfd_ixgbe_set_split_erop(uint16_t port_id, uint16_t vf_id, int state);
+int vfd_ixgbe_get_split_ctlreg(uint16_t port_id, uint16_t vf_id);
+int vfd_ixgbe_dump_all_vlans(uint16_t port_id);
 
 #endif
 

--- a/src/vfd/vfd_mlx5.c
+++ b/src/vfd/vfd_mlx5.c
@@ -9,7 +9,7 @@
 #include <string.h>
 
 int
-vfd_mlx5_get_ifname(uint8_t port_id, char *ifname)
+vfd_mlx5_get_ifname(uint16_t port_id, char *ifname)
 {
 	struct rte_eth_dev_info dev_info;
 	rte_eth_dev_info_get(port_id, &dev_info);
@@ -21,7 +21,7 @@ vfd_mlx5_get_ifname(uint8_t port_id, char *ifname)
 }
 
 int
-vfd_mlx5_get_num_vfs(uint8_t port_id)
+vfd_mlx5_get_num_vfs(uint16_t port_id)
 {
 	char ifname[IF_NAMESIZE];
 	char cmd[128] = "";
@@ -47,7 +47,7 @@ vfd_mlx5_get_num_vfs(uint8_t port_id)
 }
 
 int
-vfd_mlx5_set_vf_link_status(uint8_t port_id, uint16_t vf_id, int status)
+vfd_mlx5_set_vf_link_status(uint16_t port_id, uint16_t vf_id, int status)
 {
 	char ifname[IF_NAMESIZE];
 	char link_state[16]= "";
@@ -83,7 +83,7 @@ vfd_mlx5_set_vf_link_status(uint8_t port_id, uint16_t vf_id, int status)
 }
 
 int 
-vfd_mlx5_set_vf_mac_addr(uint8_t port_id, uint16_t vf_id, const char* mac)
+vfd_mlx5_set_vf_mac_addr(uint16_t port_id, uint16_t vf_id, const char* mac)
 {
 	char ifname[IF_NAMESIZE];
 	char cmd[128] = "";
@@ -104,7 +104,7 @@ vfd_mlx5_set_vf_mac_addr(uint8_t port_id, uint16_t vf_id, const char* mac)
 }
 
 int
-vfd_mlx5_vf_mac_remove(uint8_t port_id, uint16_t vf_id)
+vfd_mlx5_vf_mac_remove(uint16_t port_id, uint16_t vf_id)
 {
 	char ifname[IF_NAMESIZE];
 	char cmd[128] = "";
@@ -125,7 +125,7 @@ vfd_mlx5_vf_mac_remove(uint8_t port_id, uint16_t vf_id)
 }
 
 int 
-vfd_mlx5_set_vf_vlan_stripq(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_mlx5_set_vf_vlan_stripq(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 	char ifname[IF_NAMESIZE];
 	char vf_id_s[8] = "";
@@ -143,7 +143,7 @@ vfd_mlx5_set_vf_vlan_stripq(uint8_t port_id, uint16_t vf_id, uint8_t on)
 
 
 int 
-vfd_mlx5_set_vf_vlan_insert(uint8_t port_id, uint16_t vf_id, uint16_t vlan_id)
+vfd_mlx5_set_vf_vlan_insert(uint16_t port_id, uint16_t vf_id, uint16_t vlan_id)
 {
 	char ifname[IF_NAMESIZE];
 	char cmd[128] = "";
@@ -164,7 +164,7 @@ vfd_mlx5_set_vf_vlan_insert(uint8_t port_id, uint16_t vf_id, uint16_t vlan_id)
 }
 
 int
-vfd_mlx5_set_vf_rate_limit(uint8_t port_id, uint16_t vf_id, uint16_t rate)
+vfd_mlx5_set_vf_rate_limit(uint16_t port_id, uint16_t vf_id, uint16_t rate)
 {
 	char ifname[IF_NAMESIZE];
 	char cmd[128] = "";
@@ -185,7 +185,7 @@ vfd_mlx5_set_vf_rate_limit(uint8_t port_id, uint16_t vf_id, uint16_t rate)
 }
 
 int
-vfd_mlx5_set_vf_mac_anti_spoof(uint8_t port_id, uint16_t vf_id, uint8_t on)
+vfd_mlx5_set_vf_mac_anti_spoof(uint16_t port_id, uint16_t vf_id, uint8_t on)
 {
 	char ifname[IF_NAMESIZE];
 	char cmd[128] = "";
@@ -205,7 +205,7 @@ vfd_mlx5_set_vf_mac_anti_spoof(uint8_t port_id, uint16_t vf_id, uint8_t on)
 }
 
 uint32_t
-vfd_mlx5_get_pf_spoof_stats(uint8_t port_id)
+vfd_mlx5_get_pf_spoof_stats(uint16_t port_id)
 {
 	char ifname[IF_NAMESIZE];
 	//FILE *fp;
@@ -263,7 +263,7 @@ vfd_mlx5_get_vf_ethtool_counter(char *ifname, const char *counter)
 }
 
 uint64_t
-vfd_mlx5_get_vf_spoof_stats(uint8_t port_id, uint16_t vf_id)
+vfd_mlx5_get_vf_spoof_stats(uint16_t port_id, uint16_t vf_id)
 {
 	char ifname[IF_NAMESIZE];
 	char tx_err_cnt[64] = "";
@@ -277,7 +277,7 @@ vfd_mlx5_get_vf_spoof_stats(uint8_t port_id, uint16_t vf_id)
 }
 
 int
-vfd_mlx5_get_vf_stats(uint8_t port_id, uint16_t vf_id, struct rte_eth_stats *stats)
+vfd_mlx5_get_vf_stats(uint16_t port_id, uint16_t vf_id, struct rte_eth_stats *stats)
 {
 	char ifname[IF_NAMESIZE];
 	char tx_err_cnt[64] = "";
@@ -323,7 +323,7 @@ vfd_mlx5_pf_vf_offset(char *pciid)
 }
 
 int
-vfd_mlx5_set_prio_trust(uint8_t port_id)
+vfd_mlx5_set_prio_trust(uint16_t port_id)
 {
 	char ifname[IF_NAMESIZE];
 	char cmd[128] = "";
@@ -344,7 +344,7 @@ vfd_mlx5_set_prio_trust(uint8_t port_id)
 }
 
 int
-vfd_mlx5_set_qos_pf(uint8_t port_id, sriov_port_t *pf)
+vfd_mlx5_set_qos_pf(uint16_t port_id, sriov_port_t *pf)
 {
 	char ifname[IF_NAMESIZE];
 	char cmd[256] = "";

--- a/src/vfd/vfd_mlx5.h
+++ b/src/vfd/vfd_mlx5.h
@@ -12,23 +12,23 @@ struct mlx5_tc_cfg {
 };
 
 // ------------- prototypes ----------------------------------------------
-int vfd_mlx5_get_ifname(uint8_t port_id, char *ifname);
+int vfd_mlx5_get_ifname(uint16_t port_id, char *ifname);
 
-int vfd_mlx5_set_vf_mac_addr(uint8_t port, uint16_t vf_id, const char *mac_addr);
-int vfd_mlx5_vf_mac_remove(uint8_t port_id, uint16_t vf_id);
-int vfd_mlx5_set_vf_vlan_stripq(uint8_t port, uint16_t vf, uint8_t on);
-int vfd_mlx5_set_vf_vlan_insert(uint8_t port, uint16_t vf_id, uint16_t vlan_id);
-int vfd_mlx5_set_vf_mac_anti_spoof(uint8_t port_id, uint16_t vf_id, uint8_t on);
-int vfd_mlx5_set_vf_rate_limit(uint8_t port_id, uint16_t vf_id, uint16_t rate);
-int vfd_mlx5_set_vf_link_status(uint8_t port_id, uint16_t vf_id, int status);
-uint32_t vfd_mlx5_get_pf_spoof_stats(uint8_t port_id);
-int vfd_mlx5_get_num_vfs(uint8_t port_id);
-int vfd_mlx5_get_vf_stats(uint8_t port_id, uint16_t vf_id, struct rte_eth_stats *stats);
+int vfd_mlx5_set_vf_mac_addr(uint16_t port, uint16_t vf_id, const char *mac_addr);
+int vfd_mlx5_vf_mac_remove(uint16_t port_id, uint16_t vf_id);
+int vfd_mlx5_set_vf_vlan_stripq(uint16_t port, uint16_t vf, uint8_t on);
+int vfd_mlx5_set_vf_vlan_insert(uint16_t port, uint16_t vf_id, uint16_t vlan_id);
+int vfd_mlx5_set_vf_mac_anti_spoof(uint16_t port_id, uint16_t vf_id, uint8_t on);
+int vfd_mlx5_set_vf_rate_limit(uint16_t port_id, uint16_t vf_id, uint16_t rate);
+int vfd_mlx5_set_vf_link_status(uint16_t port_id, uint16_t vf_id, int status);
+uint32_t vfd_mlx5_get_pf_spoof_stats(uint16_t port_id);
+int vfd_mlx5_get_num_vfs(uint16_t port_id);
+int vfd_mlx5_get_vf_stats(uint16_t port_id, uint16_t vf_id, struct rte_eth_stats *stats);
 uint64_t vfd_mlx5_get_vf_sysfs_counter(char *ifname, const char *counter,  uint16_t vf_id);
 uint64_t vfd_mlx5_get_vf_ethtool_counter(char *ifname, const char *counter);
-uint64_t vfd_mlx5_get_vf_spoof_stats(uint8_t port_id, uint16_t vf_id);
+uint64_t vfd_mlx5_get_vf_spoof_stats(uint16_t port_id, uint16_t vf_id);
 int vfd_mlx5_pf_vf_offset(char *pciid);
-int vfd_mlx5_set_qos_pf(uint8_t port_id, sriov_port_t *pf);
-int vfd_mlx5_set_prio_trust(uint8_t port_id);
+int vfd_mlx5_set_qos_pf(uint16_t port_id, sriov_port_t *pf);
+int vfd_mlx5_set_prio_trust(uint16_t port_id);
 
 #endif


### PR DESCRIPTION
Building VFd against 17.11 was failing. This patch fixes that.

Signed-off-by: Ajit Khaparde <ajit.khaparde@broadcom.com>